### PR TITLE
Add prefix and fix #3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!--
+- Fix [#XXX](https://github.com/compulim/bookstore/issues/XXX). Fixed something, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/bookstore/pull/XXX).
+-->
+
 ## [Unreleased]
+
+### Added
+
+- `createStorageUsingAzureStorage`: Now supports `prefix`, in PR [#4](https://github.com/compulim/bookstore/pull/4).
+- `createStorageUsingAzureStorage`: Blobs with invalid metadata will be default to `undefined`, in PR [#4](https://github.com/compulim/bookstore/pull/4).
+
+### Fixed
+
+- Fix [#4](https://github.com/compulim/bookstore/issues/4). Fix `update` did not send `id` to `summarizer`, by [@compulim](https://github.com/compulim), in PR [#3](https://github.com/compulim/bookstore/pull/3).
 
 ## [2.2.0] - 2019-02-18
 
 ### Added
 
-- Fix [#1](https://github.com/compulim/bookstore/issues/1). `summarizer` will receive `id` of the page as the second argument, in PR [#2](https://github.com/compulim/bookstore/pull/2)
+- Fix [#1](https://github.com/compulim/bookstore/issues/1). `summarizer` will receive `id` of the page as the second argument, in PR [#2](https://github.com/compulim/bookstore/pull/2).
 
 ## [2.1.0] - 2018-12-30
 
 ### Changed
 
-- Use [`fast-deep-equal@2.0.1`](https://npmjs.com/package/fast-deep-equal) for deep equality check, by [@compulim](https://github.com/compulim) in commit [5f5b3b6](https://github.com/compulim/bookstore/commit/5f5b3b64464ba6c33d0aeec86154682465a98c0c)
+- Use [`fast-deep-equal@2.0.1`](https://npmjs.com/package/fast-deep-equal) for deep equality check, by [@compulim](https://github.com/compulim) in commit [5f5b3b6](https://github.com/compulim/bookstore/commit/5f5b3b64464ba6c33d0aeec86154682465a98c0c).
 
 ## [2.0.0] - 2018-12-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2387,7 +2387,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2408,12 +2409,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2428,17 +2431,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2555,7 +2561,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2567,6 +2574,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2581,6 +2589,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2588,12 +2597,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2612,6 +2623,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2692,7 +2704,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2704,6 +2717,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2789,7 +2803,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2825,6 +2840,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2844,6 +2860,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2887,12 +2904,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3362,7 +3381,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -5166,6 +5186,11 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "on-error-resume-next": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-error-resume-next/-/on-error-resume-next-1.1.0.tgz",
+      "integrity": "sha512-XhWMbmKV0+W95yLJjT1Z9zdkKiPUjDn63YYsji1pdvKqaa7pq4coeHaHEXPsa36SFlffOyOlPK/0rn6Njfb+LA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.5",
     "azure-storage": "^2.10.2",
+    "on-error-resume-next": "^1.1.0",
     "redis": "^2.8.0",
     "simple-update-in": "^2.0.2"
   }

--- a/src/PromisifiedBlobService.js
+++ b/src/PromisifiedBlobService.js
@@ -69,10 +69,11 @@ class PromisifiedBlobService {
     });
   }
 
-  listBlobsSegmented(container, currentToken, options) {
+  listBlobsSegmentedWithPrefix(container, prefix, currentToken, options) {
     return new Promise((resolve, reject) => {
-      this.blobService.listBlobsSegmented(
+      this.blobService.listBlobsSegmentedWithPrefix(
         container,
+        prefix,
         currentToken,
         options,
         (err, entries) => err ? reject(err) : resolve(entries)

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ export default function (summarizer, facility) {
       const nextContent = await updater(content);
 
       changed = !Object.is(nextContent, content);
-      nextSummary = changed ? await summarizer(nextContent) : summary;
+      nextSummary = changed ? await summarizer(nextContent, id) : summary;
 
       return {
         content: nextContent,


### PR DESCRIPTION
### Added

- `createStorageUsingAzureStorage`: Now supports `prefix`, in PR [#4](https://github.com/compulim/bookstore/pull/4).
- `createStorageUsingAzureStorage`: Blobs with invalid metadata will be default to `undefined`, in PR [#4](https://github.com/compulim/bookstore/pull/4).

### Fixed

- Fix [#4](https://github.com/compulim/bookstore/issues/4). Fix `update` did not send `id` to `summarizer`, by [@compulim](https://github.com/compulim), in PR [#3](https://github.com/compulim/bookstore/pull/3).
